### PR TITLE
[FIX] `to_api` resolution on naive lists

### DIFF
--- a/helpscout/base_model.py
+++ b/helpscout/base_model.py
@@ -82,9 +82,17 @@ class BaseModel(properties.HasProperties):
             return value.to_api()
 
         if isinstance(attribute_type, properties.List):
-            return [v.to_api() for v in value]
+            return self._parse_api_value_list(value)
 
         return attribute_type.serialize(value)
+
+    def _parse_api_value_list(self, values):
+        """Return a list field compatible with the API."""
+        try:
+            return [v.to_api() for v in values]
+        # Not models
+        except AttributeError:
+            return list(values)
 
     @staticmethod
     def get_non_empty_vals(mapping):

--- a/helpscout/tests/test_base_model.py
+++ b/helpscout/tests/test_base_model.py
@@ -6,6 +6,7 @@ import properties
 import unittest
 
 from datetime import datetime
+from six import string_types
 
 from .. import BaseModel
 from ..exceptions import HelpScoutValidationException
@@ -89,6 +90,14 @@ class TestBaseModel(unittest.TestCase):
         res = self.new_record().to_api()
         self.assertIsInstance(res['list'], list)
         self.assertIsInstance(res['list'][0], dict)
+
+    def test_to_api_list_string(self):
+        """It should properly handle naive lists."""
+        expect = ['1', '2']
+        self.test_values['list_string'] = expect
+        res = self.new_record().to_api()
+        self.assertIsInstance(res['listString'], list)
+        self.assertIsInstance(res['listString'][0], string_types)
 
     def test_to_api_date(self):
         """It should return the serialized datetime."""


### PR DESCRIPTION
* Add a try/except to allow for `to_api` on non-model lists