### PR TITLE
[FIX] tags property in Conversation

### DIFF
--- a/helpscout/models/conversation.py
+++ b/helpscout/models/conversation.py
@@ -72,5 +72,5 @@ class Conversation(BaseConversation):
     )
     tags = properties.List(
         'Tags for the conversation',
-        prop=Tag,
+        prop=properties.String('Tag Name'),
     )


### PR DESCRIPTION
* `tags` property in `Conversation` object is a list of tag name strings, not tag objects