### PR TITLE
[FIX] Camelcase Attachment model property

### DIFF
--- a/helpscout/models/attachment.py
+++ b/helpscout/models/attachment.py
@@ -16,7 +16,7 @@ class Attachment(BaseModel):
     mime_type = properties.String(
         'Mime Type',
     )
-    filename = properties.String(
+    file_name = properties.String(
         'File Name',
         required=True,
     )


### PR DESCRIPTION
Changes `filename` to `file_name`