### PR TITLE
[FIX] Handle null response body from delete methods

### DIFF
--- a/helpscout/base_api.py
+++ b/helpscout/base_api.py
@@ -71,10 +71,10 @@ class BaseApi(object):
         )
         if singleton:
             results = paginator.call(paginator.data)
-            result_length = len(results)
-            if result_length == 0:
+            try:
+                return out_type.from_api(**results[0])
+            except (IndexError, TypeError):
                 return None
-            return out_type.from_api(**results[0])
         obj = super(BaseApi, cls).__new__(cls)
         obj.paginator = paginator
         return obj

--- a/helpscout/request_paginator/__init__.py
+++ b/helpscout/request_paginator/__init__.py
@@ -143,7 +143,7 @@ class RequestPaginator(object):
             kwargs['verify'] = self.SSL_VERIFY
 
         response = method(*args, **kwargs)
-        response_json = response.json()
+        response_json = response.text and response.json() or {}
 
         if response.status_code < 200 or response.status_code >= 300:
             message = response_json.get('error', response_json.get('message'))
@@ -162,4 +162,4 @@ class RequestPaginator(object):
         except KeyError:
             pass
 
-        return True
+        return None

--- a/helpscout/tests/test_base_api.py
+++ b/helpscout/tests/test_base_api.py
@@ -61,9 +61,16 @@ class TestBaseApi(unittest.TestCase):
         self.assertEqual(res.id, 9876)
 
     @mock.patch(PAGINATOR)
-    def test_new_paginator_singleton_none(self, paginator):
+    def test_new_paginator_singleton_not_found(self, paginator):
         """It should return None if singleton and not found."""
         paginator().call.return_value = []
+        res = self.new_api(singleton=True)
+        self.assertIs(res, None)
+
+    @mock.patch(PAGINATOR)
+    def test_new_paginator_singleton_none(self, paginator):
+        """It should return None if singleton and return value is None."""
+        paginator().call.return_value = None
         res = self.new_api(singleton=True)
         self.assertIs(res, None)
 


### PR DESCRIPTION
* Set response_json to empty dict if no response body
* Return None from RequestPaginator._call if no response body
* Return None instead of API object if no response body

Depends on:
- [x] https://github.com/LasLabs/python-helpscout/pull/36