### PR TITLE
[FIX] Avoid silencing parsing errors

### DIFF
--- a/helpscout/base_api.py
+++ b/helpscout/base_api.py
@@ -72,9 +72,10 @@ class BaseApi(object):
         if singleton:
             results = paginator.call(paginator.data)
             try:
-                return out_type.from_api(**results[0])
+                result = results[0]
             except (IndexError, TypeError):
                 return None
+            return out_type.from_api(**result)
         obj = super(BaseApi, cls).__new__(cls)
         obj.paginator = paginator
         return obj


### PR DESCRIPTION
Move `from_api` call out of try clause to avoid silencing errors during api response parsing (e.g. `TypeError`s caused by mismatched property types)