### PR TITLE
[FIX] Fix Conversation and Thread properties

### DIFF
--- a/helpscout/models/conversation.py
+++ b/helpscout/models/conversation.py
@@ -68,11 +68,15 @@ class Conversation(BaseConversation):
     )
     cc = properties.List(
         'Emails that are CCd.',
-        prop=Email,
+        prop=properties.String(
+            'Email Address',
+        ),
     )
     bcc = properties.List(
         'Emails that are BCCd.',
-        prop=Email,
+        prop=properties.String(
+            'Email Address',
+        ),
     )
     tags = properties.List(
         'Tags for the conversation',

--- a/helpscout/models/conversation.py
+++ b/helpscout/models/conversation.py
@@ -6,7 +6,6 @@ import properties
 
 from .base_conversation import BaseConversation
 
-from .email import Email
 from .mailbox_ref import MailboxRef
 from .person import Person
 from .source import Source

--- a/helpscout/models/thread.py
+++ b/helpscout/models/thread.py
@@ -48,7 +48,7 @@ class Thread(BaseModel):
                  'importedExternal',
                  'changedTicketCustomer',
                  'deletedTicket',
-                 'restoreTicket',
+                 'restoredTicket',
                  'originalCreator',
                  ],
     )

--- a/helpscout/models/thread.py
+++ b/helpscout/models/thread.py
@@ -7,7 +7,6 @@ import properties
 from .. import BaseModel
 
 from .attachment import Attachment
-from .email import Email
 from .mailbox_ref import MailboxRef
 from .person import Person
 from .source import Source

--- a/helpscout/models/thread.py
+++ b/helpscout/models/thread.py
@@ -111,15 +111,21 @@ class Thread(BaseModel):
     )
     to = properties.List(
         'Email to',
-        prop=Email,
+        prop=properties.String(
+            'Email Address',
+        ),
     )
     cc = properties.List(
         'CC to',
-        prop=Email,
+        prop=properties.String(
+            'Email Address',
+        ),
     )
     bcc = properties.List(
         'BCC to',
-        prop=Email,
+        prop=properties.String(
+            'Email Address',
+        ),
     )
     attachments = properties.List(
         'Attachments',


### PR DESCRIPTION
Changes To/CC/BCC properties on Thread and Conversation models to lists of strings, rather than lists of Email objects.

Also fixes a typo (also present in HelpScout documentation) in the Thread action_type choices.