### PR TITLE
[FIX] Use '*' search query if none provided

### DIFF
--- a/helpscout/domain/__init__.py
+++ b/helpscout/domain/__init__.py
@@ -81,6 +81,8 @@ class Domain(properties.HasProperties):
 
     def __str__(self):
         """Return a string usable as the query in an API request."""
+        if not self.query:
+            return '*'
         return '(%s)' % ' '.join([str(q) for q in self.query])
 
 

--- a/helpscout/tests/test_api_conversations.py
+++ b/helpscout/tests/test_api_conversations.py
@@ -116,7 +116,7 @@ class TestApiConversations(ApiCommon):
         )
 
     def test_search(self):
-        data = {'query': "()"}
+        data = {'query': "*"}
         self._test_method(
             Conversations, 'search', [[]], '/search/conversations.json', data,
             out_type=SearchConversation,


### PR DESCRIPTION
Currently, the library searches with an empty query `'()'` if no search query is provided, resulting in no records being returned.

This changes the fallback query to `'*'`, which returns all records and is consistent with the [default behavior](https://developer.helpscout.com/help-desk-api/search/conversations/#request) of the HelpScout API.