### PR TITLE
[FIX] Fix Conversations, Customers endpoints

### DIFF
--- a/helpscout/apis/conversations.py
+++ b/helpscout/apis/conversations.py
@@ -8,7 +8,6 @@ from ..models.attachment import Attachment
 from ..models.attachment_data import AttachmentData
 from ..models.conversation import Conversation
 from ..models.search_conversation import SearchConversation
-from ..models.thread import Thread
 
 from ..request_paginator import RequestPaginator
 
@@ -82,12 +81,13 @@ class Conversations(BaseApi):
         Returns:
             helpscout.models.Conversation: Newly created conversation.
         """
-        data = {
-            'conversation': conversation.to_api(),
+        data = conversation.to_api()
+        params = {
             'imported': imported,
             'auto_reply': auto_reply,
             'reload': True,
         }
+        data.update(params)
         return cls(
             '/conversations.json',
             data=data,
@@ -145,20 +145,21 @@ class Conversations(BaseApi):
              emails or notifications will be generated.
 
         Returns:
-            helpscout.models.Thread: Newly created thread.
+            helpscout.models.Conversation: Conversation including newly created
+                thread.
         """
-        data = {
-            'thread': thread.to_api(),
+        data = thread.to_api()
+        params = {
             'imported': imported,
             'reload': True,
         }
+        data.update(params)
         return cls(
             '/conversations/%s.json' % conversation.id,
             data=data,
             request_type=RequestPaginator.POST,
             singleton=True,
             session=session,
-            out_type=Thread,
         )
 
     @classmethod
@@ -373,7 +374,8 @@ class Conversations(BaseApi):
             thread (helpscout.models.Thread): The thread to be updated.
 
         Returns:
-            helpscout.models.Thread: Freshly updated thread.
+            helpscout.models.Conversation: Conversation including freshly
+                updated thread.
         """
         data = thread.to_api()
         data['reload'] = True
@@ -385,5 +387,4 @@ class Conversations(BaseApi):
             request_type=RequestPaginator.PUT,
             singleton=True,
             session=session,
-            out_type=Thread,
         )

--- a/helpscout/apis/customers.py
+++ b/helpscout/apis/customers.py
@@ -45,10 +45,8 @@ class Customers(BaseApi):
         Returns:
             helpscout.models.Customer: Newly created customer.
         """
-        data = {
-            'customer': customer.to_api(),
-            'reload': True,
-        }
+        data = customer.to_api()
+        data['reload'] = True
         return cls(
             '/customers.json',
             data=data,

--- a/helpscout/tests/test_api_conversations.py
+++ b/helpscout/tests/test_api_conversations.py
@@ -9,7 +9,6 @@ from ..apis.conversations import Conversations
 from ..models.search_conversation import SearchConversation
 from ..models.attachment import Attachment
 from ..models.attachment_data import AttachmentData
-from ..models.thread import Thread
 
 
 class TestApiConversations(ApiCommon):
@@ -21,12 +20,12 @@ class TestApiConversations(ApiCommon):
         )
 
     def test_create(self):
-        data = {
-            'conversation': self.mock_record.to_api(),
+        data = self.mock_record
+        data.update({
             'imported': True,
             'auto_reply': True,
             'reload': True,
-        }
+        })
         args = [self.mock_record, True, True]
         self._test_method(
             Conversations, 'create', args, '/conversations.json',
@@ -42,17 +41,16 @@ class TestApiConversations(ApiCommon):
         )
 
     def test_create_thread(self):
-        thread = self.mock_record.thread
-        data = {
-            'thread': thread.to_api(),
+        data = self.mock_record.thread
+        data.update({
             'imported': True,
             'reload': True,
-        }
+        })
         args = [self.mock_record, self.mock_record.thread, True]
         uri = '/conversations/%d.json' % self.mock_record.id
         self._test_method(
             Conversations, 'create_thread', args, uri,
-            data, 'post', True, Thread,
+            data, 'post', True,
         )
 
     def test_delete(self):
@@ -137,5 +135,5 @@ class TestApiConversations(ApiCommon):
         )
         self._test_method(
             Conversations, 'update_thread', [self.mock_record, thread], uri,
-            thread, singleton=True, out_type=Thread,
+            thread, singleton=True,
         )


### PR DESCRIPTION
* Fixes the incorrect structure of the request bodies sent in the `create_conversation`, `create_thread`, and `create_customer` actions, which was resulting in validation errors.
* Removes the `Thread` `out_type` set in the `create_thread` and `update_thread` actions, as the HelpScout responses are `Conversation` objects, not `Thread` objects.